### PR TITLE
set half right part of screen to go back and half left part to go further

### DIFF
--- a/e_metrobus/static/sass/_display_route.scss
+++ b/e_metrobus/static/sass/_display_route.scss
@@ -105,6 +105,7 @@
   transform: translateY(-50%);
   width: 50%;
   z-index: 99999;
+  height: 100%;
 
   &--previous {
     left: 0;


### PR DESCRIPTION
It is not as nice as swiping (#214) but it is still more user friendly than tapping on just a small arrow

fix #218 