### PR TITLE
add higher z-index to share icons

### DIFF
--- a/e_metrobus/static/sass/_quiz_finished.scss
+++ b/e_metrobus/static/sass/_quiz_finished.scss
@@ -46,6 +46,7 @@
   }
   &__icon {
     text-align: center;
+    z-index: 9999;
 
     img {
       width: 3rem;


### PR DESCRIPTION
@henhuy not sure if this is going to fix since it displayed correctly both in the Firefox emlulator (Linux) and on my both android devices using Firefox. Maybe it is just a problem with z-index.