### PR TITLE
fix jumping page on display_route and comparison

### DIFF
--- a/e_metrobus/static/sass/_layout.scss
+++ b/e_metrobus/static/sass/_layout.scss
@@ -36,7 +36,7 @@ $top-bar-height: 2.8rem;
 	}
 	&.l-scroll--nofooter {
 		.main-content {
-			height: calc(100vh - #{$top-bar-height});
+			height: calc(100% - #{$top-bar-height});
 			margin-bottom: 0;
 		}
 		section.footer {


### PR DESCRIPTION
Same issue as before because of the mobile browser search box. I did a small change. It seems to work properly now with the Chrome emulator. I would check it again after it has been merged into the master branch.

fix #274 