### PR TITLE
add accordion with dummy pictures to summary page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 ### Added
 - posthog for anonymous session tracking
 
+### Changed 
+- Implemented tabs on summary page
+
 ## [0.13.0] - 2020-06-29
 ### Changed
 - Removed answer score page; correct/wrong answer is showed on answer page

--- a/e_metrobus/static/sass/_questions_as_text.scss
+++ b/e_metrobus/static/sass/_questions_as_text.scss
@@ -23,6 +23,9 @@
 }
 
 .project-content {
+  .tabs-content {
+    border: none;
+  }
   ul {
     margin-bottom: 0;
   }

--- a/e_metrobus/static/sass/_questions_as_text.scss
+++ b/e_metrobus/static/sass/_questions_as_text.scss
@@ -21,3 +21,37 @@
     margin: 1rem 0;
   }
 }
+
+.project-content {
+  ul {
+    margin-bottom: 0;
+  }
+  .accordion-title:hover,
+  .accordion-title:focus {
+    background-color: $white;
+  }
+  .accordion-item span.project-content__icon {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    transform: translateY(1px);
+    background-image: url(../images/icons/i_next_black_large.svg);
+    background-size: cover;
+  }
+  .accordion-item.is-active span.project-content__icon {
+    background-image: url(../images/icons/i_previous_black_large.svg);
+  }
+  :last-child > .accordion-content:last-child {
+    border: none;
+  }
+  .accordion-content {
+    border: none;
+    padding: 0 1rem 1.5rem;
+  }
+  .project-content__heading {
+    font-size: 1.25rem;
+    font-weight: 700;
+    display: inline-block;
+    padding-top: .75rem;
+  }
+}

--- a/e_metrobus/templates/navigation/questions_as_text.html
+++ b/e_metrobus/templates/navigation/questions_as_text.html
@@ -5,29 +5,31 @@
 <div class="cell project custom-tabs">
   <ul class="tabs custom-tabs__tabs" data-tabs id="question_tabs">
     {% for cat_name, category in categories.items %}
-      <li class="tabs-title{% if forloop.first %} is-active{% endif %}"><a href="#{{cat_name}}" aria-selected="true">{{category.get_label}}</a></li>
+      <li class="tabs-title {% if forloop.first %}is-active{% endif %}"><a href="#{{cat_name}}" aria-selected="true">{{category.get_label}}</a></li>
     {% endfor %}
   </ul>
 </div>
 <div class="cell project-content">
   <div class="tabs-content" data-tabs-content="question_tabs">
     {% for cat_name, category in categories.items %}
-      <ul class="accordion" data-accordion data-allow-all-closed="true" id="{{cat_name}}">
-        {% for q_name, question in category.questions.items %}
-            {% if q_name != "route" %}
-            <li class="accordion-item" data-accordion-item>
-              <a href="#" class="questionstext__questlabel accordion-title">
-                <img class="project-content__img" src="/static/images/questions/pantograph.png">
-                <span class="project-content__icon"></span>
-                <span class="project-content__heading">{{question.get_label}}</span>
-              </a>
-              <div class="accordion-content project__question" data-tab-content>
-                {% include question.template %}
-              </div>
-            </li>
-            {% endif %}
-          {% endfor %}
-        </ul>
+      <div class="tabs-panel {% if forloop.first %}is-active{% endif %}" id="{{cat_name}}">
+        <ul class="accordion" data-accordion data-allow-all-closed="true">
+          {% for q_name, question in category.questions.items %}
+              {% if q_name != "route" %}
+              <li class="accordion-item" data-accordion-item>
+                <a href="#" class="questionstext__questlabel accordion-title">
+                  <img class="project-content__img" src="/static/images/questions/pantograph.png">
+                  <span class="project-content__icon"></span>
+                  <span class="project-content__heading">{{question.get_label}}</span>
+                </a>
+                <div class="accordion-content project__question" data-tab-content>
+                  {% include question.template %}
+                </div>
+              </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+      </div>
     {% endfor %}
   </div>
 </div>

--- a/e_metrobus/templates/navigation/questions_as_text.html
+++ b/e_metrobus/templates/navigation/questions_as_text.html
@@ -8,18 +8,26 @@
       <li class="tabs-title{% if forloop.first %} is-active{% endif %}"><a href="#{{cat_name}}" aria-selected="true">{{category.get_label}}</a></li>
     {% endfor %}
   </ul>
+</div>
+<div class="cell project-content">
   <div class="tabs-content" data-tabs-content="question_tabs">
     {% for cat_name, category in categories.items %}
-      <div class="tabs-panel is-active" id="{{cat_name}}">
+      <ul class="accordion" data-accordion data-allow-all-closed="true" id="{{cat_name}}">
         {% for q_name, question in category.questions.items %}
             {% if q_name != "route" %}
-              <div class="questionstext__questlabel"><h3>{{question.get_label}}</h3></div>
-              <div class="project__question">
+            <li class="accordion-item" data-accordion-item>
+              <a href="#" class="questionstext__questlabel accordion-title">
+                <img class="project-content__img" src="/static/images/questions/pantograph.png">
+                <span class="project-content__icon"></span>
+                <span class="project-content__heading">{{question.get_label}}</span>
+              </a>
+              <div class="accordion-content project__question" data-tab-content>
                 {% include question.template %}
               </div>
+            </li>
             {% endif %}
           {% endfor %}
-      </div>
+        </ul>
     {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
@henhuy I added an accordion from Foundation and also dummy pictures. Now the user should be able to tap on an image/heading to open/close the accordion item. This is working so far. 

But I don't know how to display the correct accordion items corresponding to the right tab item ('E-MetroBus', 'Umwelt', 'Politik', 'Ich'). Plus I had a look at our production version and there is a display issue too. After loading the page, the "E-MetroBus" tab is highlighted, but all the items are present ('CO2-Reduktion', 'Zeitplan' and 'Vorteile' should not be there). Then if you tap on the "Umwelt' tab, the 'CO2-Reduktion', 'Zeitplan' and 'Vorteile' items are there ('Zeitplan' and 'Vorteile' should not be there). But then if I tap on 'Politik' and 'Ich' and then back to 'Umwelt', only 'CO2-Reduktion' is there...

fix #312 