### PR TITLE
add dummy flash icons to question page

### DIFF
--- a/e_metrobus/static/sass/_question.scss
+++ b/e_metrobus/static/sass/_question.scss
@@ -1,24 +1,15 @@
-.progress-bar {
-  height: .75rem;
-  width: 100%;
-  background-color: $gray-3;
-  position: relative;
-
-  &__fill {
-    background-color: $primary-color-2;
-    height: 100%;
-
-    &--correct {
-      position: absolute;
-      top: 0;
-    }
+.top-flash {
+  padding-top: 1.5rem;
+  text-align: center;
+  img {
+    height: 1.25rem;
   }
 }
 
 .question{
 
   &__text {
-    margin: 1.5rem 1rem .5rem;
+    margin: 1rem 1rem .5rem;
   }
   &__answer input {
     margin: 0;

--- a/e_metrobus/templates/navigation/question.html
+++ b/e_metrobus/templates/navigation/question.html
@@ -4,14 +4,16 @@
 {% load i18n %}
 
 {% block content %}
-<div class="cell progress-bar">
-  <div class="progress-bar__fill" style="background-color: #E46C6C; width: {{category_percentage_done}}%;"></div>
-  <div class="progress-bar__fill progress-bar__fill--correct" style="width: {{category_percentage_correct}}%;"></div>
-</div>
 <div class="cell question">
   <form method="post" action="{% url 'navigation:question' category=question.category %}" id="question">
     <input type="hidden" name="question" value="{{question.name}}">
     <div class="grid-x align-center">
+      <div class="cell top-flash">
+        <img src="/static/images/icons/i_flash_correct.svg" alt="">
+        <img src="/static/images/icons/i_flash_correct.svg" alt="">
+        <img src="/static/images/icons/i_flash_wrong.svg" alt="">
+        <img src="/static/images/icons/i_flash_empty.svg" alt="">
+      </div>
       <div class="cell small-10 question__text">
         {% csrf_token %}
         <h2>{% trans question.question %}</h2>


### PR DESCRIPTION
@henhuy I only added the flash icons to the question page. I was trying to see how it would look to have them on the answer page too, but it looks overloaded with elements. So for now, I would just keep them there.

In comparison to the bar we use to have, I think that each flash could represent a question. I.e. if first question answered was wrong, first flash will be red. If second question answered was correct, second flash will be blue, etc. Can you organize that section and make it work dynamically? Thanks!

fix #318 