### PR TITLE
style error pages

### DIFF
--- a/e_metrobus/navigation/urls.py
+++ b/e_metrobus/navigation/urls.py
@@ -1,4 +1,8 @@
+
+from django.conf import settings
+from django.http import Http404
 from django.urls import path
+from django.views.defaults import page_not_found, permission_denied, server_error
 
 from e_metrobus.navigation import views
 
@@ -37,3 +41,10 @@ urlpatterns = [
     path("accept_privacy_policy/", views.accept_privacy_policy),
     path("send_posthog_event/", views.send_posthog_event),
 ]
+
+if settings.DEBUG:
+    urlpatterns += [
+        path('500/', server_error),
+        path('404/', page_not_found, {'exception': Http404()}),
+        path('403/', permission_denied, {'exception': Http404()}),
+    ]

--- a/e_metrobus/static/sass/_error.scss
+++ b/e_metrobus/static/sass/_error.scss
@@ -18,4 +18,9 @@
       width: 12rem;
     }
   }
+
+  .error-layout__btn {
+    text-align: center;
+    padding-top: 5.5rem;
+  }
 }

--- a/e_metrobus/static/sass/_error.scss
+++ b/e_metrobus/static/sass/_error.scss
@@ -1,0 +1,21 @@
+.error-layout {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1rem;
+
+  .error-layout__content {
+    text-align: center;
+  }
+
+  .error-layout__img {
+    padding-top: 5rem;
+    text-align: center;
+
+    img {
+      width: 12rem;
+    }
+  }
+}

--- a/e_metrobus/static/sass/app.scss
+++ b/e_metrobus/static/sass/app.scss
@@ -24,6 +24,7 @@
 @import 'sass/confetti';
 @import 'sass/feedback';
 @import 'sass/tour';
+@import 'sass/error';
 @import 'libs/foundation-sites/scss/foundation';
 
 @include foundation-global-styles;

--- a/e_metrobus/templates/403.html
+++ b/e_metrobus/templates/403.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
 
-{% block title %}Forbidden (403){% endblock %}
+{% block title %}{% trans 'Verboten' %} (403){% endblock %}
 
 {% block content %}
 <div class="error-layout">
   <div class="error-layout__content">
-    <h1>Forbidden (403)</h1>
-    <p>CSRF verification failed. Request aborted.</p>
+    <h1>{% trans 'Verboten' %} (403)</h1>
+    <p>{% trans 'CSRF Verifizierung fehlgeschlagen. Anfrage wurde abgewiesen. %}</p>
   </div>
   <div class="error-layout__img">
-    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="Elektrischer Bus ohne Strom">
+    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
   </div>
 </div>
 

--- a/e_metrobus/templates/403.html
+++ b/e_metrobus/templates/403.html
@@ -11,6 +11,9 @@
   <div class="error-layout__img">
     <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
   </div>
+  <div class="error-layout__btn">
+    <a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zum App" %}</button></a>
+  </div>
 </div>
 
 {% endblock content %}

--- a/e_metrobus/templates/403.html
+++ b/e_metrobus/templates/403.html
@@ -3,7 +3,14 @@
 {% block title %}Forbidden (403){% endblock %}
 
 {% block content %}
-<h1>Forbidden (403)</h1>
+<div class="error-layout">
+  <div class="error-layout__content">
+    <h1>Forbidden (403)</h1>
+    <p>CSRF verification failed. Request aborted.</p>
+  </div>
+  <div class="error-layout__img">
+    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="Elektrischer Bus ohne Strom">
+  </div>
+</div>
 
-<p>CSRF verification failed. Request aborted.</p>
 {% endblock content %}

--- a/e_metrobus/templates/403.html
+++ b/e_metrobus/templates/403.html
@@ -1,18 +1,20 @@
 {% extends "base.html" %}
 
+{% load i18n %}
+
 {% block title %}{% trans 'Verboten' %} (403){% endblock %}
 
 {% block content %}
 <div class="error-layout">
   <div class="error-layout__content">
     <h1>{% trans 'Verboten' %} (403)</h1>
-    <p>{% trans 'CSRF Verifizierung fehlgeschlagen. Anfrage wurde abgewiesen. %}</p>
+    <p>{% trans 'CSRF Verifizierung fehlgeschlagen. Anfrage wurde abgewiesen.' %}</p>
   </div>
   <div class="error-layout__img">
     <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
   </div>
   <div class="error-layout__btn">
-    <a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zum App" %}</button></a>
+    <a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zur App" %}</button></a>
   </div>
 </div>
 

--- a/e_metrobus/templates/404.html
+++ b/e_metrobus/templates/404.html
@@ -13,5 +13,8 @@
   <div class="error-layout__img">
     <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
   </div>
+  <div class="error-layout__btn">
+    <a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zum App" %}</button></a>
+  </div>
 </div>
 {% endblock content %}

--- a/e_metrobus/templates/404.html
+++ b/e_metrobus/templates/404.html
@@ -1,15 +1,17 @@
 {% extends "base.html" %}
 
-{% block title %}Page not found{% endblock %}
+{% load i18n %}
+
+{% block title %}{% trans 'Seite nicht gefunden' %}{% endblock %}
 
 {% block content %}
 <div class="error-layout">
   <div class="error-layout__content">
-    <h1>Page not found</h1>
-    <p>This is not the page you were looking for.</p>
+    <h1>{% trans 'Seite nicht gefunden' %}</h1>
+    <p>{% trans 'Dies ist nicht die gewünschte Seite.' %}</p>
   </div>
   <div class="error-layout__img">
-    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="Elektrischer Bus ohne Strom">
+    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
   </div>
 </div>
 {% endblock content %}

--- a/e_metrobus/templates/404.html
+++ b/e_metrobus/templates/404.html
@@ -14,7 +14,7 @@
     <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
   </div>
   <div class="error-layout__btn">
-    <a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zum App" %}</button></a>
+    <a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zur App" %}</button></a>
   </div>
 </div>
 {% endblock content %}

--- a/e_metrobus/templates/404.html
+++ b/e_metrobus/templates/404.html
@@ -3,7 +3,13 @@
 {% block title %}Page not found{% endblock %}
 
 {% block content %}
-<h1>Page not found</h1>
-
-<p>This is not the page you were looking for.</p>
+<div class="error-layout">
+  <div class="error-layout__content">
+    <h1>Page not found</h1>
+    <p>This is not the page you were looking for.</p>
+  </div>
+  <div class="error-layout__img">
+    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="Elektrischer Bus ohne Strom">
+  </div>
+</div>
 {% endblock content %}

--- a/e_metrobus/templates/500.html
+++ b/e_metrobus/templates/500.html
@@ -1,16 +1,15 @@
 {% extends "base.html" %}
 
-{% block title %}Server Error{% endblock %}
+{% block title %}{% trans 'Server Fehler' %}{% endblock %}
 
 {% block content %}
 <div class="error-layout">
 	<div class="error-layout__content">
-		<h1>Ooops!!! 500</h1>
-		<h3>Looks like something went wrong!</h3>
-		<p>We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing.</p>
+		<h1>{% trans 'Oh - ein Server Fehler!' %}</h1>
+		<h3>{% trans 'Etwas ist schief gelaufen' %}</h3>
 	</div>
 	<div class="error-layout__img">
-    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="Elektrischer Bus ohne Strom">
+    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
   </div>
 </div>
 {% endblock content %}

--- a/e_metrobus/templates/500.html
+++ b/e_metrobus/templates/500.html
@@ -3,11 +3,16 @@
 {% block title %}Server Error{% endblock %}
 
 {% block content %}
-<h1>Ooops!!! 500</h1>
-
-<h3>Looks like something went wrong!</h3>
-
-<p>We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing.</p>
+<div class="error-layout">
+	<div class="error-layout__content">
+		<h1>Ooops!!! 500</h1>
+		<h3>Looks like something went wrong!</h3>
+		<p>We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing.</p>
+	</div>
+	<div class="error-layout__img">
+    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="Elektrischer Bus ohne Strom">
+  </div>
+</div>
 {% endblock content %}
 
 

--- a/e_metrobus/templates/500.html
+++ b/e_metrobus/templates/500.html
@@ -9,7 +9,10 @@
 		<h3>{% trans 'Etwas ist schief gelaufen' %}</h3>
 	</div>
 	<div class="error-layout__img">
-    <img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
+    	<img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
+  </div>
+  <div class="error-layout__btn">
+	<a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zum App" %}</button></a>
   </div>
 </div>
 {% endblock content %}

--- a/e_metrobus/templates/500.html
+++ b/e_metrobus/templates/500.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load i18n %}
+
 {% block title %}{% trans 'Server Fehler' %}{% endblock %}
 
 {% block content %}
@@ -12,7 +14,7 @@
     	<img class="project-content__img" src="/static/images/icons/Icon_E_Bus_BVG_empty_battery.svg" alt="{% trans 'Elektrischer Bus ohne Strom' %}">
   </div>
   <div class="error-layout__btn">
-	<a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zum App" %}</button></a>
+	<a href="{% url 'navigation:dashboard' %}"><button class="button">{% trans "Zurück zur App" %}</button></a>
   </div>
 </div>
 {% endblock content %}

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-30 09:31+0200\n"
+"POT-Creation-Date: 2020-07-01 12:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,37 +18,142 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: e_metrobus/navigation/chart.py:46
-msgid "Zu Fuß"
-msgstr "On foot"
+#: e_metrobus/navigation/chart.py:47
+msgid "Zu Fuß/<br>Fahrrad"
+msgstr ""
 
-#: e_metrobus/navigation/chart.py:46 e_metrobus/navigation/constants.py:84
-msgid "Fahrrad"
-msgstr "Bike"
-
-#: e_metrobus/navigation/chart.py:46
+#: e_metrobus/navigation/chart.py:47
 msgid "E-Bus"
 msgstr "E-bus"
 
-#: e_metrobus/navigation/chart.py:46 e_metrobus/navigation/constants.py:72
+#: e_metrobus/navigation/chart.py:47
+msgid "E-Pkw"
+msgstr ""
+
+#: e_metrobus/navigation/chart.py:47 e_metrobus/navigation/constants.py:72
 msgid "Dieselbus"
 msgstr "Diesel"
 
-#: e_metrobus/navigation/chart.py:46 e_metrobus/navigation/constants.py:66
+#: e_metrobus/navigation/chart.py:47
+msgid "Pkw"
+msgstr ""
+
+#: e_metrobus/navigation/chart.py:78
+#, fuzzy
+#| msgid "CO2 Emissionen [in g]<br>nach Verkehrsmittel"
+msgid "CO<sub>2</sub> Emissionen [in g]<br>nach Verkehrsmittel"
+msgstr "CO2 emissions [in g]<br>per vehicle"
+
+#: e_metrobus/navigation/constants.py:67
 msgid "PKW"
 msgstr "Car"
 
-#: e_metrobus/navigation/chart.py:77
-msgid "CO2 Emissionen [in g]<br>nach Verkehrsmittel"
-msgstr "CO2 emissions [in g]<br>per vehicle"
+#: e_metrobus/navigation/constants.py:75
+#, fuzzy
+#| msgid "Elektrobus"
+msgid "Elektro-PKW"
+msgstr "E-Bus"
 
-#: e_metrobus/navigation/constants.py:78
+#: e_metrobus/navigation/constants.py:76
 msgid "Elektrobus"
 msgstr "E-Bus"
 
-#: e_metrobus/navigation/constants.py:90
+#: e_metrobus/navigation/constants.py:77
+msgid "Fahrrad"
+msgstr "Bike"
+
+#: e_metrobus/navigation/constants.py:78
 msgid "zu Fuß"
 msgstr "On foot"
+
+#: e_metrobus/navigation/models.py:30
+msgid "Technisches Problem"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:31
+msgid "Schwierigkeit bei der Nutzung der App"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:32
+msgid "Inkorrekter oder unverständlicher Inhalt"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:33
+msgid "Anderes"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:37
+msgid "Etwas funktioniert nicht? Ein Link ist kaputt?"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:40
+msgid "Ist etwas schwierig oder frustrierend zu nutzen?"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:42
+msgid "Um welchen Inhalt geht es?"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:43
+msgid "Kannst du uns dein Problem beschreiben?"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:46
+msgid "Problem"
+msgstr ""
+
+#: e_metrobus/navigation/models.py:48
+msgid "Beschreibung"
+msgstr ""
+
+#: e_metrobus/navigation/widgets.py:93
+msgid "Quiz"
+msgstr ""
+
+#: e_metrobus/navigation/widgets.py:100
+#, fuzzy
+#| msgid "Stecker"
+msgid "Meine Strecke"
+msgstr "Plug"
+
+#: e_metrobus/navigation/widgets.py:107
+#, fuzzy
+#| msgid "E-Metrobus"
+msgid "E-MetroBus"
+msgstr "E-Metrobus"
+
+#: e_metrobus/navigation/widgets.py:114
+msgid "Infos"
+msgstr ""
+
+#: e_metrobus/templates/403.html:3 e_metrobus/templates/403.html:8
+msgid "Verboten"
+msgstr "Forbidden"
+
+#: e_metrobus/templates/403.html:12 e_metrobus/templates/404.html:14
+#: e_metrobus/templates/500.html:12
+msgid "Elektrischer Bus ohne Strom"
+msgstr "E-Bus without electricity"
+
+#: e_metrobus/templates/404.html:5 e_metrobus/templates/404.html:10
+msgid "Seite nicht gefunden"
+msgstr "Page not found"
+
+#: e_metrobus/templates/404.html:11
+msgid "Dies ist nicht die gewünschte Seite."
+msgstr "This is not the page you were looking for."
+
+#: e_metrobus/templates/500.html:3
+msgid "Server Fehler"
+msgstr "Server Error"
+
+#: e_metrobus/templates/500.html:8
+msgid "Oh - ein Server Fehler!"
+msgstr "Ooops!!! - Server Error"
+
+#: e_metrobus/templates/500.html:9
+msgid "Etwas ist schief gelaufen"
+msgstr "Something went wrong."
 
 #: e_metrobus/templates/includes/desktop.html:11
 #: e_metrobus/templates/includes/landscape.html:7
@@ -64,25 +169,25 @@ msgstr ""
 "Electrification of MetroBus lines in Berlin public transport with fast-"
 "charging infrastructure"
 
-#: e_metrobus/templates/includes/desktop.html:27
+#: e_metrobus/templates/includes/desktop.html:41
 msgid "App auf mobilen Geräten verfügbar"
 msgstr "App available on mobile devices"
 
-#: e_metrobus/templates/includes/desktop.html:44
+#: e_metrobus/templates/includes/desktop.html:58
 msgid "Laufzeit"
 msgstr "Project duration"
 
-#: e_metrobus/templates/includes/desktop.html:45
+#: e_metrobus/templates/includes/desktop.html:59
 msgid ""
 "Das E-MetroBus Projekt läuft für einen Zeitraum von Januar 2019 bis Januar "
 "2023"
 msgstr "The E-MetroBus project runs from January 2019 to January 2023"
 
-#: e_metrobus/templates/includes/desktop.html:49
+#: e_metrobus/templates/includes/desktop.html:63
 msgid "Förderung"
 msgstr "Funding"
 
-#: e_metrobus/templates/includes/desktop.html:50
+#: e_metrobus/templates/includes/desktop.html:64
 msgid ""
 "Die Förderung erfolgt als ein Forschungs- und Entwicklungsvorhaben im Rahmen "
 "der Förderrichtlinie Elektromobilität des Bundesministeriums für Verkehr und "
@@ -92,11 +197,11 @@ msgstr ""
 "framework of the Electromobility Funding Directive of the Federal Ministry "
 "of Transport and Digital Infrastructure"
 
-#: e_metrobus/templates/includes/desktop.html:54
+#: e_metrobus/templates/includes/desktop.html:68
 msgid "Busse"
 msgstr "Buses"
 
-#: e_metrobus/templates/includes/desktop.html:55
+#: e_metrobus/templates/includes/desktop.html:69
 msgid ""
 "Um möglichst lange ladungsbedingte Standzeiten zu vermeiden, müssen die "
 "Busse in der Lage sein, mit einer hohen Leistung geladen zu werden"
@@ -104,11 +209,11 @@ msgstr ""
 "In order to avoid charge-related downtimes for as long as possible, the "
 "buses must be able to be charge at high power"
 
-#: e_metrobus/templates/includes/desktop.html:59
+#: e_metrobus/templates/includes/desktop.html:73
 msgid "Ladeinfrastruktur"
 msgstr "Charging infrastructure"
 
-#: e_metrobus/templates/includes/desktop.html:60
+#: e_metrobus/templates/includes/desktop.html:74
 msgid ""
 "Eine Ladeinfrastruktur von über 300kW soll erprobt werden. Der resultierende "
 "Bedarf soll sowohl mit den eigens aus Erneuerbaren Energien produziertem "
@@ -118,11 +223,11 @@ msgstr ""
 "resulting demand is to be met with both electricity generated from renewable "
 "energy sources and from the supply network"
 
-#: e_metrobus/templates/includes/desktop.html:68
+#: e_metrobus/templates/includes/desktop.html:82
 msgid "Projektziele"
 msgstr "Project goals"
 
-#: e_metrobus/templates/includes/desktop.html:70
+#: e_metrobus/templates/includes/desktop.html:84
 msgid ""
 "Im Projekt E-MetroBus werden 15 Gelenkbusse der Berliner Verkehrsbetriebe "
 "(BVG) elektrifiziert und so ausgerüstet, dass sie besonders schnell geladen "
@@ -144,7 +249,7 @@ msgstr ""
 "particularly clear when all 1400 buses in the BVG fleet are included in the "
 "study"
 
-#: e_metrobus/templates/includes/desktop.html:73
+#: e_metrobus/templates/includes/desktop.html:87
 msgid ""
 "Das RLI entwickelt unterschiedliche Szenarien, wie eine lokale, "
 "netzdienliche Versorgung der Ladestationen erreicht werden kann. Dabei "
@@ -175,54 +280,58 @@ msgstr ""
 "Please visit the page in portrait mode if you are interested in the E-"
 "Metrobus project."
 
-#: e_metrobus/templates/navigation/answer.html:23
-msgid "RICHTIG!"
-msgstr "CORRECT!"
+#: e_metrobus/templates/navigation/answer.html:10
+msgid "Korrekt"
+msgstr ""
 
-#: e_metrobus/templates/navigation/answer.html:45
-msgid "FALSCH..."
-msgstr "WRONG..."
+#: e_metrobus/templates/navigation/answer.html:10
+msgid "Falsch"
+msgstr ""
 
-#: e_metrobus/templates/navigation/answer.html:74
+#: e_metrobus/templates/navigation/answer.html:17
 msgid "Zur nächsten Frage"
 msgstr "To the next question"
 
-#: e_metrobus/templates/navigation/category_finished.html:15
-msgid "Glückwunsch!"
-msgstr "Congratulations!"
-
-#: e_metrobus/templates/navigation/category_finished.html:19
-#, python-format
-msgid "Du hast die Kategorie %(cat_label)s abgeschlossen!"
+#: e_metrobus/templates/navigation/category_finished.html:17
+#, fuzzy, python-format
+#| msgid "Du hast die Kategorie %(cat_label)s abgeschlossen!"
+msgid "Kategorie %(cat_label)s abgeschlossen!"
 msgstr "You finished category %(cat_label)s!"
 
-#: e_metrobus/templates/navigation/comparison.html:18
+#: e_metrobus/templates/navigation/comparison.html:25
+#: e_metrobus/templates/navigation/comparison.html:27
 msgid "Mehr entdecken!"
 msgstr "Discover more!"
 
-#: e_metrobus/templates/navigation/dashboard.html:35
-msgid ""
-"Hier kannst Du weiter entdecken und Spaß mit dem Quiz haben! Die erste Frage "
-"hast Du schon beantwortet!"
-msgstr ""
-"Here you can learn more and have fun with the quiz! You have already "
-"answered the first question!"
-
-#: e_metrobus/templates/navigation/display_route.html:46
+#: e_metrobus/templates/navigation/display_route.html:50
 msgid "Deine Strecke mit dem <span>E-Bus</span> beträgt"
 msgstr "Your route with the <span>E-Bus</span> is"
 
-#: e_metrobus/templates/navigation/display_route.html:68
-msgid "Im Vergleich zum <span>Dieselbus</span> sparst Du"
-msgstr "In comparison to a <span>diesel bus</span> you are saving"
-
-#: e_metrobus/templates/navigation/display_route.html:86
-msgid "Im Vergleich zum <span>Pkw</span> sparst Du"
+#: e_metrobus/templates/navigation/display_route.html:72
+#, fuzzy
+#| msgid "Im Vergleich zum <span>Pkw</span> sparst Du"
+msgid "Im Vergleich zum <span>E-PKW</span> sparst du"
 msgstr "In comparison to a <span>passenger car</span> you are saving"
 
-#: e_metrobus/templates/navigation/display_route.html:104
+#: e_metrobus/templates/navigation/display_route.html:91
+#, fuzzy
+#| msgid "Im Vergleich zum <span>Dieselbus</span> sparst Du"
+msgid "Im Vergleich zum <span>Dieselbus</span> sparst du"
+msgstr "In comparison to a <span>diesel bus</span> you are saving"
+
+#: e_metrobus/templates/navigation/display_route.html:110
+#, fuzzy
+#| msgid "Im Vergleich zum <span>Pkw</span> sparst Du"
+msgid "Im Vergleich zum <span>Pkw</span> sparst du"
+msgstr "In comparison to a <span>passenger car</span> you are saving"
+
+#: e_metrobus/templates/navigation/display_route.html:129
+#, fuzzy
+#| msgid ""
+#| "Nur noch <span>zu Fuß</span> oder mit dem <span>Fahrrad</span> kannst Du "
+#| "es besser machen!"
 msgid ""
-"Nur noch <span>zu Fuß</span> oder mit dem <span>Fahrrad</span> kannst Du es "
+"Nur noch <span>zu Fuß</span> oder mit dem <span>Fahrrad</span> kannst du es "
 "besser machen!"
 msgstr ""
 "You can only do better <span>on foot</span> or with the <span>bike</span>!"
@@ -266,8 +375,8 @@ msgstr "Tonnes"
 
 #: e_metrobus/templates/navigation/environment.html:69
 #: e_metrobus/templates/widgets/info_table.html:10
-msgid "CO2"
-msgstr "CO2"
+msgid "CO<sub>2</sub>"
+msgstr ""
 
 #: e_metrobus/templates/navigation/environment.html:77
 #: e_metrobus/templates/navigation/environment.html:81
@@ -283,50 +392,114 @@ msgstr "Nitrogen oxide"
 msgid "Feinstaub"
 msgstr "Particulate matter"
 
-#: e_metrobus/templates/navigation/feedback.html:18
-msgid "Meinung schicken"
-msgstr "Send feedback"
+#: e_metrobus/templates/navigation/finished_base.html:15
+#, fuzzy, python-format
+#| msgid "Glückwunsch du hast das Quiz mit %(score)s Punkten abgeschlossen!"
+msgid "Glückwunsch!<br>Du hast das Quiz mit %(score)s Punkten abgeschlossen!"
+msgstr "Congratulations! You finished the quiz with %(score)s points."
 
-#: e_metrobus/templates/navigation/feedback.html:21
-msgid "Überspringen"
-msgstr "Skip"
+#: e_metrobus/templates/navigation/finished_base.html:28
+msgid "Quiz neu starten"
+msgstr "Restart the quiz"
 
-#: e_metrobus/templates/navigation/landing_page.html:21
+#: e_metrobus/templates/navigation/landing_page.html:14
 msgid "Toll, dass du mit einem E-Bus fährst!"
 msgstr "It's great that you are taking an E-Bus!"
 
-#: e_metrobus/templates/navigation/landing_page.html:24
+#: e_metrobus/templates/navigation/landing_page.html:17
 msgid "Zeig mir warum!"
 msgstr "Show me why!"
 
-#: e_metrobus/templates/navigation/legal.html:10
-msgid "Legale Informationen"
-msgstr "Legal information"
+#: e_metrobus/templates/navigation/landing_page.html:67
+msgid "Okay"
+msgstr ""
 
-#: e_metrobus/templates/navigation/question.html:18
+#: e_metrobus/templates/navigation/legal.html:9
+#, fuzzy
+#| msgid "Projektziele"
+msgid "Projektpartner"
+msgstr "Project goals"
+
+#: e_metrobus/templates/navigation/legal.html:10
+#: e_metrobus/templates/widgets/info_table.html:28
+msgid "Quellen"
+msgstr ""
+
+#: e_metrobus/templates/navigation/legal.html:11
+msgid "Feedback geben"
+msgstr ""
+
+#: e_metrobus/templates/navigation/legal.html:44
+msgid "Meinung schicken"
+msgstr "Send feedback"
+
+#: e_metrobus/templates/navigation/legal.html:45
+msgid "Fehler melden"
+msgstr ""
+
+#: e_metrobus/templates/navigation/legal.html:70
+#, fuzzy
+#| msgid "30 Sekunden"
+msgid "Senden"
+msgstr "30 seconds"
+
+#: e_metrobus/templates/navigation/question.html:23
 msgid "Mehrere Antworten möglich"
 msgstr "Multiple answers possible"
 
-#: e_metrobus/templates/navigation/question.html:35
+#: e_metrobus/templates/navigation/question.html:40
 msgid "Antworten"
 msgstr "Answers"
 
-#: e_metrobus/templates/navigation/quiz_finished.html:15
-#, python-format
-msgid "Glückwunsch du hast das Quiz mit %(score)s Punkten abgeschlossen!"
-msgstr "Congratulations! You finished the quiz with %(score)s points."
-
-#: e_metrobus/templates/navigation/quiz_finished.html:25
-msgid "Link zum Teilen deiner Punkte:"
-msgstr "Link to share your points:"
-
-#: e_metrobus/templates/navigation/quiz_finished.html:29
+#: e_metrobus/templates/navigation/quiz_finished.html:12
 msgid "Ergebnis teilen"
 msgstr "Share the result"
 
-#: e_metrobus/templates/navigation/quiz_finished.html:37
-msgid "Quiz neu starten"
-msgstr "Restart the quiz"
+#: e_metrobus/templates/navigation/quiz_finished.html:36
+#: e_metrobus/templates/widgets/top_bar.html:61
+msgid "Link wurde kopiert"
+msgstr ""
+
+#: e_metrobus/templates/navigation/route_dropdown.html:21
+msgid "Wo bist du eingestiegen?"
+msgstr ""
+
+#: e_metrobus/templates/navigation/route_dropdown.html:37
+msgid "Wo steigst du aus?"
+msgstr ""
+
+#: e_metrobus/templates/navigation/route_dropdown.html:50
+#: e_metrobus/templates/widgets/stations.html:52
+msgid "Strecke bestätigen"
+msgstr "Confirm route"
+
+#: e_metrobus/templates/navigation/route_dropdown.html:58
+msgid "Ein- und Ausstieg müssen verschieden sein."
+msgstr ""
+
+#: e_metrobus/templates/navigation/tour.html:14
+msgid "Du weißt jetzt, wie viel CO<sub>2</sub> du auf dieser Strecke sparst!"
+msgstr ""
+
+#: e_metrobus/templates/navigation/tour.html:20
+msgid "Jetzt kannst du..."
+msgstr ""
+
+#: e_metrobus/templates/navigation/tour.html:28
+msgid "... deine Kenntnisse über E-Mobilität mit einem Quiz testen!"
+msgstr ""
+
+#: e_metrobus/templates/navigation/tour.html:36
+msgid "... noch mehr Daten zu deiner Strecke und der Umwelt-Bilanz lesen"
+msgstr ""
+
+#: e_metrobus/templates/navigation/tour.html:44
+msgid "... über das E-MetroBus Projekt erfahren"
+msgstr ""
+
+#: e_metrobus/templates/navigation/tour.html:50
+msgid "Alles klar!"
+msgstr ""
 
 #: e_metrobus/templates/pages/question_translations.html:5
 msgid "E-Metrobus"
@@ -393,20 +566,30 @@ msgid "Umwelt"
 msgstr "Environment"
 
 #: e_metrobus/templates/pages/question_translations.html:32
-msgid "CO2 Reduktion"
+#, fuzzy
+#| msgid "CO2 Reduktion"
+msgid "CO<sub>2</sub> Reduktion"
 msgstr "CO2 reduction"
 
 #: e_metrobus/templates/pages/question_translations.html:33
+#, fuzzy
+#| msgid ""
+#| "Wie viel CO2 werden durch den Einsatz der Elektrobusse auf der Linie 200 "
+#| "jährlich eingespart?"
 msgid ""
-"Wie viel CO2 werden durch den Einsatz der Elektrobusse auf der Linie 200 "
-"jährlich eingespart?"
+"Wie viel CO<sub>2</sub> werden durch den Einsatz der Elektrobusse auf der "
+"Linie 200 jährlich eingespart?"
 msgstr ""
 "How much CO2 will be saved annually by using the electric buses on line 200?"
 
 #: e_metrobus/templates/pages/question_translations.html:36
+#, fuzzy
+#| msgid ""
+#| "444 t CO2 können durch die Elektrifizierung der Linie 200 pro Jahr "
+#| "eongespart werden"
 msgid ""
-"444 t CO2 können durch die Elektrifizierung der Linie 200 pro Jahr "
-"eongespart werden"
+"444 t CO<sub>2</sub> können durch die Elektrifizierung der Linie 200 pro "
+"Jahr eongespart werden"
 msgstr ""
 "444 tonnes of CO2 can be saved per year through the electrification of line "
 "200"
@@ -444,11 +627,16 @@ msgstr ""
 "possible)"
 
 #: e_metrobus/templates/pages/question_translations.html:56
-msgid "Weniger CO2-Belastung"
+#, fuzzy
+#| msgid "Weniger CO2-Belastung"
+msgid "Weniger CO<sub>2</sub>-Belastung"
 msgstr "Less CO2 pollution"
 
 #: e_metrobus/templates/pages/question_translations.html:58
-msgid "Vorteile sind unte anderem eine geringere CO2- und Lärm-Belastung"
+#, fuzzy
+#| msgid "Vorteile sind unte anderem eine geringere CO2- und Lärm-Belastung"
+msgid ""
+"Vorteile sind unte anderem eine geringere CO<sub>2</sub>- und Lärm-Belastung"
 msgstr ""
 "Advantages are, among others, a reduction in both CO2 and noise pollution"
 
@@ -463,14 +651,23 @@ msgstr ""
 "planned to be used on this line initially.\n"
 
 #: e_metrobus/templates/questions/e_metrobus/loading.html:5
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "Der Bus wird an den Endhaltestellen Hertzallee und Michelangelostraße mit "
+#| "einem Pantographen aufgeladen. Dieser ist in der Ladesäule integriert. "
+#| "Wenn der Bus unter der Ladesäule steht, wird der Pantograph "
+#| "heruntergefahren und verbindet sich mit den Schienen auf dem Dach des "
+#| "Busses. Geladen wird in wenigen Minuten mit 450 kW. Wird die Leistung mit "
+#| "einem handelsüblichen Wasserkocher verglichen (etwa 2 kW Leistung) "
+#| "entspricht die Ladeleistung 225 Wasserkochern.\n"
 msgid ""
 "\n"
 "Der Bus wird an den Endhaltestellen Hertzallee und Michelangelostraße mit "
 "einem Pantographen aufgeladen. Dieser ist in der Ladesäule integriert. Wenn "
 "der Bus unter der Ladesäule steht, wird der Pantograph heruntergefahren und "
 "verbindet sich mit den Schienen auf dem Dach des Busses. Geladen wird in "
-"wenigen Minuten mit 450 kW. Wird die Leistung mit einem handelsüblichen "
-"Wasserkocher verglichen (etwa 2 kW Leistung) entspricht die Ladeleistung 225 "
+"wenigen Minuten mit 450 kW. Das entspricht der Leistung von etwa 225 "
 "Wasserkochern.\n"
 msgstr ""
 "\n"
@@ -495,13 +692,21 @@ msgstr ""
 "few minutes\n"
 
 #: e_metrobus/templates/questions/environment/co2_reduction.html:4
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "E-Busse sind lokal komplett emissionsfrei. Mit der Elektrifizierung der "
+#| "Buslinie 200 werden pro Fahrt circa 15 kg CO2 eingespart. Auf das Jahr "
+#| "hochgerechnet werden circa 444 t Co2 eingespart. Um den gleichen Effekt "
+#| "zu erreichen, müssten bei durchschnittlichem Fahrverhalten rund 12 Diesel-"
+#| "Personenkraftwagen elektrifiziert werden.\n"
 msgid ""
 "\n"
 "E-Busse sind lokal komplett emissionsfrei. Mit der Elektrifizierung der "
-"Buslinie 200 werden pro Fahrt circa 15 kg CO2 eingespart. Auf das Jahr "
-"hochgerechnet werden circa 444 t Co2 eingespart. Um den gleichen Effekt zu "
-"erreichen, müssten bei durchschnittlichem Fahrverhalten rund 12 Diesel-"
-"Personenkraftwagen elektrifiziert werden.\n"
+"Buslinie 200 werden pro Fahrt circa 15 kg CO<sub>2</sub> eingespart. Auf das "
+"Jahr hochgerechnet werden circa 444 t C0<sub>2</sub> eingespart. Um den "
+"gleichen Effekt zu erreichen, müssten bei durchschnittlichem Fahrverhalten "
+"rund 12 Diesel-Personenkraftwagen elektrifiziert werden.\n"
 msgstr ""
 "\n"
 "E-buses are locally completely emission-free. The electrification of bus "
@@ -511,15 +716,26 @@ msgstr ""
 "have to to be electrified assuming regular driving behaviour.\n"
 
 #: e_metrobus/templates/questions/personal/advantages.html:4
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "Als Fahrgast profitieren Sie von einem deutlich ruhigeren Fahrerlebnis.\n"
+#| "Elektrische Busse sind leiser als Dieselbusse und vibrieren weniger.\n"
+#| "Als Anwohner der Buslinie 200 dürfen Sie sich über eine erheblich "
+#| "geringere Lärm- und Abgasbelastung freuen.\n"
+#| "Insgesamt trägt der E-Bus so zu einem lebenswerten Berlin bei.\n"
+#| "Die Geräuschemission eines E-Busses entspricht denen eines "
+#| "durchschnittlichen PKW und ist damit um ca. die Hälfte geringer als die "
+#| "eines modernen Dieselbusmotors.\n"
 msgid ""
 "\n"
-"Als Fahrgast profitieren Sie von einem deutlich ruhigeren Fahrerlebnis.\n"
+"Als Fahrgast profitierst du von einem deutlich ruhigeren Fahrerlebnis.\n"
 "Elektrische Busse sind leiser als Dieselbusse und vibrieren weniger.\n"
-"Als Anwohner der Buslinie 200 dürfen Sie sich über eine erheblich geringere "
-"Lärm- und Abgasbelastung freuen.\n"
+"Wenn du an der Buslinie 200 wohnst, darfst du dich über eine erheblich "
+"geringere Lärm- und Abgasbelastung freuen.\n"
 "Insgesamt trägt der E-Bus so zu einem lebenswerten Berlin bei.\n"
 "Die Geräuschemission eines E-Busses entspricht denen eines "
-"durchschnittlichen PKW und ist damit um ca. die Hälfte geringer als die "
+"durchschnittlichen Pkws und ist damit um ca. die Hälfte geringer als die "
 "eines modernen Dieselbusmotors.\n"
 msgstr ""
 "\n"
@@ -533,14 +749,24 @@ msgstr ""
 "bus engine.\n"
 
 #: e_metrobus/templates/questions/politics/ebus_time.html:4
+#, fuzzy
+#| msgid ""
+#| "\n"
+#| "Ziel des Verbundprojektes E-Bus Berlin war es, eine Buslinie in Berlin "
+#| "komplett elektrisch zu betreiben. Der mehrmonatige Testbetrieb im Alltag, "
+#| "welcher am 31.08.2015 aufgenommen wurde, wurde wissenschaftlich durch die "
+#| "TU Berlin begleitet und hinsichtlich Umweltbilanz, Wirtschaftlichkeit und "
+#| "Nutzerakzeptanz bewertet. Aktuell ist die Testphase abgeschlossen und die "
+#| "Elektrobusse schon vollkommen in die Flotte der BVG integriert.\n"
 msgid ""
 "\n"
 "Ziel des Verbundprojektes E-Bus Berlin war es, eine Buslinie in Berlin "
 "komplett elektrisch zu betreiben. Der mehrmonatige Testbetrieb im Alltag, "
 "welcher am 31.08.2015 aufgenommen wurde, wurde wissenschaftlich durch die TU "
 "Berlin begleitet und hinsichtlich Umweltbilanz, Wirtschaftlichkeit und "
-"Nutzerakzeptanz bewertet. Aktuell ist die Testphase abgeschlossen und die "
-"Elektrobusse schon vollkommen in die Flotte der BVG integriert.\n"
+"Akzeptanz bei den Fahrgästen bewertet. Aktuell ist die Testphase "
+"abgeschlossen und die Elektrobusse schon vollkommen in die Flotte der BVG "
+"integriert.\n"
 msgstr ""
 "\n"
 "The aim of the joint project E-Bus Berlin has been to operate a completely "
@@ -555,21 +781,47 @@ msgstr ""
 msgid "Fahrzeug"
 msgstr ""
 
-#: e_metrobus/templates/widgets/info_table.html:27
-msgid "Quelle"
-msgstr ""
-
 #: e_metrobus/templates/widgets/stations.html:43
 msgid "Bitte gib Deine Strecke ein!"
 msgstr "Please enter your route!"
 
-#: e_metrobus/templates/widgets/stations.html:52
-msgid "Strecke bestätigen"
-msgstr "Confirm route"
-
 #: e_metrobus/templates/widgets/top_bar_route.html:10
 msgid "Strecke ändern"
 msgstr "Change route"
+
+#~ msgid "Looks like something went wrong!"
+#~ msgstr "Wrong"
+
+#~ msgid "Zu Fuß"
+#~ msgstr "On foot"
+
+#~ msgid "RICHTIG!"
+#~ msgstr "CORRECT!"
+
+#~ msgid "FALSCH..."
+#~ msgstr "WRONG..."
+
+#~ msgid "Glückwunsch!"
+#~ msgstr "Congratulations!"
+
+#~ msgid ""
+#~ "Hier kannst Du weiter entdecken und Spaß mit dem Quiz haben! Die erste "
+#~ "Frage hast Du schon beantwortet!"
+#~ msgstr ""
+#~ "Here you can learn more and have fun with the quiz! You have already "
+#~ "answered the first question!"
+
+#~ msgid "CO2"
+#~ msgstr "CO2"
+
+#~ msgid "Überspringen"
+#~ msgstr "Skip"
+
+#~ msgid "Legale Informationen"
+#~ msgstr "Legal information"
+
+#~ msgid "Link zum Teilen deiner Punkte:"
+#~ msgstr "Link to share your points:"
 
 #~ msgid "Was vermittelt die App?"
 #~ msgstr "What does the app convey?"


### PR DESCRIPTION
I styled the pages (in a very simple way). The text in German is still missing though.

Do you think the users will land on these pages very often? I mean, often as in it could have a negative impact on the app use? If this was the case we should add a link to the error page (directing to the landing page or dashboard) so that users can navigate back easily. What do you think? If the chance they arrive there is very low, we can just leave the pages as they are.

fix #329 