### PR TITLE
add data-v-offset to popup

### DIFF
--- a/e_metrobus/templates/navigation/comparison.html
+++ b/e_metrobus/templates/navigation/comparison.html
@@ -36,7 +36,7 @@
   </div>
 </div>
 
-<div class="full reveal" id="comparisonData" data-reveal>
+<div class="full reveal" id="comparisonData" data-reveal data-v-offset="0px">
   <p class="data__title">Die Daten hinter der Zahlen</p>
   {{info_table}}
   <button class="close-button" data-close aria-label="Close modal" type="button">


### PR DESCRIPTION
The popup should be at `top:0`, but it is on Chrome mobile at `top:56px`. I don't know if it's coming from Foundation's JS or it is changed by Chrome's browser. So I added a parameter from Foundation to the popup to try to fix this. I need to test it on a real mobilde device to see if it's working, though. Can you merge this so I can test it?

(see #330)