### PR TITLE
set finished category box width to 100%

### DIFF
--- a/e_metrobus/static/sass/_category_finished.scss
+++ b/e_metrobus/static/sass/_category_finished.scss
@@ -12,11 +12,13 @@
   display: flex;
   padding: 30% 1rem;
   text-align: center;
+  width: 100%;
 
   & > div {
     background-color: $primary-color-1;
     border-radius: $border-radius;
     padding: 1rem;
+    width: 100%;
   }
 
   &__text {


### PR DESCRIPTION
The issue might be because of the box width not displayed at 100% width. Since "Ich" is a shorter word, the sentence didn't take the whole width (whereas it is working properly with the other categories because they have long words). But to be sure if this is fixing it, we need to test it on a smartphone again.

fix #338 
