### PR TITLE
add data-v-offset to legal popup

### DIFF
--- a/e_metrobus/templates/navigation/legal.html
+++ b/e_metrobus/templates/navigation/legal.html
@@ -43,7 +43,7 @@
           </form>
         </div>
       </div>
-      <div class="reveal" id="bug_reveal" data-reveal>
+      <div class="reveal" id="bug_reveal" data-reveal data-v-offset="0px">
         <button class="close-button" data-close aria-label="Close modal" type="button">
           <span aria-hidden="true">&times;</span>
         </button>


### PR DESCRIPTION
It was the same issue as with the popup on comparison page which was pushed 56px to the bottom on Chrome mobile. Adding `data-v-offset="0px"` to the reveal fixed the issue.

fix #332 