### PR TITLE
Fix/tablet tabs

### DIFF
--- a/e_metrobus/static/sass/_legal.scss
+++ b/e_metrobus/static/sass/_legal.scss
@@ -24,6 +24,10 @@
       top: 35%;
       width: 100%;
       max-width: 25rem;
+      left: 0;
+      right: 0;
+      margin-left: auto;
+      margin-right: auto;
     }
   }
 }

--- a/e_metrobus/static/sass/_legal.scss
+++ b/e_metrobus/static/sass/_legal.scss
@@ -32,6 +32,18 @@
   margin-left: .5rem;
 }
 
+@media screen and (min-width: 600px) {
+  .custom-tabs.legal li {
+    width: 33.33%;
+
+    &:last-of-type a {
+      border-top-right-radius: 8px;
+      border-bottom-right-radius: 8px;
+    }
+  }
+}
+
+
 .tabs-panel#partners {
   padding-left: 0;
   padding-right: 0;

--- a/e_metrobus/templates/navigation/legal.html
+++ b/e_metrobus/templates/navigation/legal.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 
 {% block content %}
-<div class="cell custom-tabs">
+<div class="cell custom-tabs legal">
   <ul class="tabs custom-tabs__tabs" data-tabs id="question_tabs">
     <li class="tabs-title is-active"><a href="#partners" aria-selected="true">{% trans "Projektpartner" %}</a></li>
     <li class="tabs-title"><a href="#data" aria-selected="true" onclick="send_posthog_event('sources');">{% trans "Quellen" %}</a></li>
@@ -16,7 +16,7 @@
       <div class="grid-x text-center">
         <div class="cell legal__logo">
           <img src="{% static 'images/logos/Logokombi.jpg' %}" alt="Elektromobilität vor Ort, BMWI, NOW und PTJ Logo">
-        </div>
+        </div> 
       </div>
     </div>
 


### PR DESCRIPTION
One PR for 2 issues (because both small and on the same page)

Now on info page with tablet view: 

- the tabs should be aligned in one row
- the logos should be centered horizontally

fix #348
fix #349 