### PR TITLE
center route images horizontally

### DIFF
--- a/e_metrobus/static/sass/_display_route.scss
+++ b/e_metrobus/static/sass/_display_route.scss
@@ -28,6 +28,8 @@
     position: relative;
 
     img {
+      margin-left: auto;
+      margin-right: auto;
       height: 3rem;
       margin-top: 6rem;
     }


### PR DESCRIPTION
@henhuy Probably because I had changed a few things for the lanscape view, I did something that removed the center alignment for icons on display_route on portrait view. Can you check if the icons are center horizontally?