### PR TITLE
show imprint and flag on tablets and larger than 640px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project tries to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] Unreleased
+### Changed
+- legal and dgstvo links are not shown on summary page
+### Fixed
+- On some devices desktop parts were hidden 
+
 ## [1.0.3] - 2020-08-26
 ### Fixed
 - twice answers in category "me"

--- a/e_metrobus/templates/includes/desktop.html
+++ b/e_metrobus/templates/includes/desktop.html
@@ -10,7 +10,7 @@
       <span class="a-desktop a-desktop--subheader">{% trans 'Elektrifizierung von Gelenkbussen im Berliner ÖPNV mit Schnellladeinfrastruktur' %}</span>
     </div>
     {% if not summary %}
-      <div class="language-flag show-for-medium a-desktop a-desktop--lang">
+      <div class="language-flag a-desktop a-desktop--lang" style="display: none;">
         {% get_current_language as LANGUAGE_CODE %}
         {% if LANGUAGE_CODE == "de" %}
           <a href="en/?visited" data-open="language_popup">
@@ -174,7 +174,7 @@
   </div>
 </section>
 
-  <section class="desktop desktop-footer show-for-medium">
+  <section class="desktop desktop-footer" style="display: none;">
     <div class="grid-x align-center grid-width--medium">
       <div class="cell">
         <ul>
@@ -218,3 +218,17 @@
       <span aria-hidden="true">{% trans 'Zurück zur Startseite' %}</span>
     </button>
   </div>
+
+  {% block javascript %}
+  <script>
+    $( document ).ready(function() {
+      const userAgent = navigator.userAgent.toLowerCase();
+      const isTablet = /(ipad|tablet|(android(?!.*mobile))|(windows(?!.*phone)(.*touch))|kindle|playbook|silk|(puffin(?!.*(IP|AP|WP))))/.test(userAgent);
+      console.log(isTablet);
+      if (isTablet || $(window).width() >= 640) {
+        $('.desktop-footer').show();
+        $('.language-flag').show();
+      }
+    });
+  </script>
+{% endblock %}

--- a/e_metrobus/templates/includes/desktop.html
+++ b/e_metrobus/templates/includes/desktop.html
@@ -174,6 +174,7 @@
   </div>
 </section>
 
+{% if not summary %}
   <section class="desktop desktop-footer">
     <div class="grid-x align-center grid-width--medium">
       <div class="cell">
@@ -184,37 +185,38 @@
       </div>
     </div>
   </section>
+{% endif %}
 
-  <div class="reveal" id="feedback_reveal" data-reveal>
-    <button class="close-button" data-close aria-label="Close modal" type="button">
-      <span aria-hidden="true">&times;</span>
-    </button>
-    <form method="post" class="feedback__form">
-      {% csrf_token %}
-      {{feedback}}
-      <input type="hidden" name="feedback">
-      <div class="cell feedback__btn">
-        <div class="grid-x align-center text-center">
-          <div class="cell">
-            <button class="button--yellow" type="submit" style= "cursor:pointer">{% trans 'Meinung schicken' %}</button>
-          </div>
+<div class="reveal" id="feedback_reveal" data-reveal>
+  <button class="close-button" data-close aria-label="Close modal" type="button">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <form method="post" class="feedback__form">
+    {% csrf_token %}
+    {{feedback}}
+    <input type="hidden" name="feedback">
+    <div class="cell feedback__btn">
+      <div class="grid-x align-center text-center">
+        <div class="cell">
+          <button class="button--yellow" type="submit" style= "cursor:pointer">{% trans 'Meinung schicken' %}</button>
         </div>
       </div>
-    </form>
-  </div>
+    </div>
+  </form>
+</div>
 
-  <div class="full reveal legal" id="imprint_reveal" data-reveal>
-    {% include 'includes/imprint.html' %}
-    <button class="close-button" data-close aria-label="Close modal" type="button">
-      <div class="icon"></div>
-      <span aria-hidden="true">{% trans 'Zurück zur Startseite' %}</span>
-    </button>
-  </div>
+<div class="full reveal legal" id="imprint_reveal" data-reveal>
+  {% include 'includes/imprint.html' %}
+  <button class="close-button" data-close aria-label="Close modal" type="button">
+    <div class="icon"></div>
+    <span aria-hidden="true">{% trans 'Zurück zur Startseite' %}</span>
+  </button>
+</div>
 
-  <div class="full reveal legal" id="privacy_reveal" data-reveal>
-    {% include 'includes/privacy.html' %}
-    <button class="close-button" data-close aria-label="Close modal" type="button">
-      <div class="icon"></div>
-      <span aria-hidden="true">{% trans 'Zurück zur Startseite' %}</span>
-    </button>
-  </div>
+<div class="full reveal legal" id="privacy_reveal" data-reveal>
+  {% include 'includes/privacy.html' %}
+  <button class="close-button" data-close aria-label="Close modal" type="button">
+    <div class="icon"></div>
+    <span aria-hidden="true">{% trans 'Zurück zur Startseite' %}</span>
+  </button>
+</div>

--- a/e_metrobus/templates/includes/desktop.html
+++ b/e_metrobus/templates/includes/desktop.html
@@ -10,7 +10,7 @@
       <span class="a-desktop a-desktop--subheader">{% trans 'Elektrifizierung von Gelenkbussen im Berliner ÖPNV mit Schnellladeinfrastruktur' %}</span>
     </div>
     {% if not summary %}
-      <div class="language-flag a-desktop a-desktop--lang" style="display: none;">
+      <div class="language-flag a-desktop a-desktop--lang">
         {% get_current_language as LANGUAGE_CODE %}
         {% if LANGUAGE_CODE == "de" %}
           <a href="en/?visited" data-open="language_popup">
@@ -174,7 +174,7 @@
   </div>
 </section>
 
-  <section class="desktop desktop-footer" style="display: none;">
+  <section class="desktop desktop-footer">
     <div class="grid-x align-center grid-width--medium">
       <div class="cell">
         <ul>
@@ -218,17 +218,3 @@
       <span aria-hidden="true">{% trans 'Zurück zur Startseite' %}</span>
     </button>
   </div>
-
-  {% block javascript %}
-  <script>
-    $( document ).ready(function() {
-      const userAgent = navigator.userAgent.toLowerCase();
-      const isTablet = /(ipad|tablet|(android(?!.*mobile))|(windows(?!.*phone)(.*touch))|kindle|playbook|silk|(puffin(?!.*(IP|AP|WP))))/.test(userAgent);
-      console.log(isTablet);
-      if (isTablet || $(window).width() >= 640) {
-        $('.desktop-footer').show();
-        $('.language-flag').show();
-      }
-    });
-  </script>
-{% endblock %}


### PR DESCRIPTION
@henhuy I think the issue is quite important actually, because we need to show legal informations on every device in order to be legally on the safe side.

I tried to show the flag + imprint/privacy only if tablet is detected or if the window width is >= 640 px. What do you think? We would still need to test on that Lenovo tablet to be sure if it works properly.

I used the code from there: https://stackoverflow.com/questions/50195475/detect-if-device-is-tablet/53518181

fix #474 