### PR TITLE
remove width media query from LP

### DIFF
--- a/e_metrobus/static/sass/_landing_page.scss
+++ b/e_metrobus/static/sass/_landing_page.scss
@@ -322,10 +322,6 @@ $desktop-padding-xxsmall: .6rem;
 
 .desktop-app { 
 
-  @media only screen and (max-width: 639px) {
-    display: none;
-  }
-
   .desktop-app__img  {
     @media only screen and (min-width: 640px) and (max-width: 1023px) {
       text-align: center;


### PR DESCRIPTION
@henhuy As discussed yesterday, the section with the mobile device on the landing page is not displayed correctly on Lenovo Tablet. We thought that this might be because of CSS. I removed `@media only screen and (max-width: 639px) {
    display: none;
  }` but now this section is visible on mobile (which should not be the case). Since we might update the LP in the next few days with a new design, I would say that this is not so important right now. We can leave that issue open until next week and see if we need to do something on it or not.

fix #522 